### PR TITLE
Fix Gateway path predicates /api/status/**

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,4 +44,4 @@ spring:
         - id: tracking
           uri: lb://tracking-microservice
           predicates:
-            - Path=/api/status**, /api/phase/**,/api/iteration/**
+            - Path=/api/status/**, /api/phase/**,/api/iteration/**


### PR DESCRIPTION
Critical Fix. Previously missing `/`